### PR TITLE
libc: Mark libstdc++ as vendor available

### DIFF
--- a/libc/Android.bp
+++ b/libc/Android.bp
@@ -126,9 +126,6 @@ cc_defaults {
         malloc_pattern_fill_contents: {
             cflags: ["-DSCUDO_PATTERN_FILL_CONTENTS"],
         },
-        malloc_not_svelte: {
-            cflags: ["-DUSE_SCUDO"],
-        },
     },
 
     lto: {
@@ -161,7 +158,6 @@ cc_defaults {
         "libc_jemalloc_wrapper",
     ],
     header_libs: ["gwp_asan_headers"],
-    product_variables: libc_scudo_product_variables,
 }
 
 // Functions not implemented by jemalloc directly, or that need to

--- a/libc/Android.bp
+++ b/libc/Android.bp
@@ -1994,6 +1994,7 @@ cc_library {
     name: "libstdc++",
     static_ndk_lib: true,
     static_libs: ["libasync_safe"],
+    vendor_available: true,
 
     static: {
         system_shared_libs: [],


### PR DESCRIPTION
A lot of blobs still link this even on 8.1, so allow devices to build a vendor copy of it.

Change-Id: I2349478ec0507e3a5136fe89f15e7dc4bfc1a03e